### PR TITLE
Fix delete getting stuck when missing model UUID or controller config

### DIFF
--- a/controllers/charmedk8scontrolplane_controller.go
+++ b/controllers/charmedk8scontrolplane_controller.go
@@ -127,6 +127,24 @@ func (r *CharmedK8sControlPlaneReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{Requeue: true}, nil
 	}
 
+	// add the finalizer and update the object. This is equivalent registering
+	// our finalizer.
+	if !controllerutil.ContainsFinalizer(kcp, controlplanev1beta1.CharmedK8sControlPlaneFinalizer) {
+		controllerutil.AddFinalizer(kcp, controlplanev1beta1.CharmedK8sControlPlaneFinalizer)
+		if err := r.Update(ctx, kcp); err != nil {
+			return ctrl.Result{}, err
+		}
+		log.Info("added finalizer")
+		return ctrl.Result{}, nil
+	}
+
+	// examine DeletionTimestamp to determine if object is under deletion
+	if !kcp.ObjectMeta.DeletionTimestamp.IsZero() {
+		// The control plane object is being deleted
+		log.Info("deleting control plane")
+		return r.reconcileDelete(ctx, cluster, kcp)
+	}
+
 	if !cluster.Status.InfrastructureReady {
 		log.Info("cluster is not ready yet, requeueing")
 		return ctrl.Result{Requeue: true}, nil
@@ -166,25 +184,6 @@ func (r *CharmedK8sControlPlaneReconciler) Reconcile(ctx context.Context, req ct
 	if modelUUID == "" {
 		log.Info("model uuid was empty", "model", modelName)
 		return ctrl.Result{RequeueAfter: requeueTime}, nil
-	}
-
-	// examine DeletionTimestamp to determine if object is under deletion
-	if kcp.ObjectMeta.DeletionTimestamp.IsZero() {
-		// The object is not being deleted, so if it does not have our finalizer,
-		// then lets add the finalizer and update the object. This is equivalent
-		// registering our finalizer.
-		if !controllerutil.ContainsFinalizer(kcp, controlplanev1beta1.CharmedK8sControlPlaneFinalizer) {
-			controllerutil.AddFinalizer(kcp, controlplanev1beta1.CharmedK8sControlPlaneFinalizer)
-			if err := r.Update(ctx, kcp); err != nil {
-				return ctrl.Result{}, err
-			}
-			log.Info("added finalizer")
-			return ctrl.Result{}, nil
-		}
-	} else {
-		// The control plane object is being deleted
-		log.Info("deleting control plane")
-		return r.reconcileDelete(ctx, cluster, kcp)
 	}
 
 	// Update ownerrefs on infra templates


### PR DESCRIPTION
I had a CharmedK8sControlPlane resource get stuck in a deleting state, with this in the controller logs:

```
1.678826198792702e+09 INFO  deleting control plane  {"controller": "charmedk8scontrolplane", "controllerGroup": "controlplane.cluster.x-k8s.io", "controllerKind": "CharmedK8sControlPlane", "CharmedK8sControlPlane": {"name":"charmedk8scontrolplane-sample","namespace":"default"}, "namespace": "default", "name": "charmedk8scontrolplane-sample", "reconcileID": "f43a3e21-af12-47d5-9c6f-17a9b915dd33"}
1.6788262289821777e+09  INFO  model uuid was empty  {"controller": "charmedk8scontrolplane", "controllerGroup": "controlplane.cluster.x-k8s.io", "controllerKind": "CharmedK8sControlPlane", "CharmedK8sControlPlane": {"name":"charmedk8scontrolplane-sample","namespace":"default"}, "namespace": "default", "name": "charmedk8scontrolplane-sample", "reconcileID": "409154f8-88d5-464d-b5c2-8ed152312312", "model": "jujucluster-sample"}
1.6788262589827003e+09  INFO  juju controller configuration was nil, requeuing  {"controller": "charmedk8scontrolplane", "controllerGroup": "controlplane.cluster.x-k8s.io", "controllerKind": "CharmedK8sControlPlane", "CharmedK8sControlPlane": {"name":"charmedk8scontrolplane-sample","namespace":"default"}, "namespace": "default", "name": "charmedk8scontrolplane-sample", "reconcileID": "96bcfdf6-9cc0-4afa-b605-e61424e301a5"}
1.678826288983429e+09 INFO  juju controller configuration was nil, requeuing  {"controller": "charmedk8scontrolplane", "controllerGroup": "controlplane.cluster.x-k8s.io", "controllerKind": "CharmedK8sControlPlane", "CharmedK8sControlPlane": {"name":"charmedk8scontrolplane-sample","namespace":"default"}, "namespace": "default", "name": "charmedk8scontrolplane-sample", "reconcileID": "7a2d3826-f5d3-4fa4-a90c-98ab60ea093d"}
< last message repeats forever >
```

Fix this by moving delete handling earlier in the reconcile function, before we try to fetch Juju info that we don't need.

I followed the pattern used by the reference KubeadmControlPlane controller implementation, which first [registers its finalizer](https://github.com/kubernetes-sigs/cluster-api/blob/a32f66e745751a514148ea3e259c897984563a01/controlplane/kubeadm/internal/controllers/controller.go#L173-L187), then [reconciles deletion](https://github.com/kubernetes-sigs/cluster-api/blob/a32f66e745751a514148ea3e259c897984563a01/controlplane/kubeadm/internal/controllers/controller.go#L217-L227), immediately after the IsPaused check. I think that should work for us too, yeah?