### PR TITLE
Status reconciliation

### DIFF
--- a/api/v1beta1/charmedk8scontrolplane_types.go
+++ b/api/v1beta1/charmedk8scontrolplane_types.go
@@ -107,6 +107,7 @@ type CharmedK8sControlPlaneStatus struct {
 
 	// Initialized is true when the target cluster has completed initialization such that at least once,
 	// the target's control plane has been contactable.
+	// +optional
 	Initialized bool `json:"initialized"`
 }
 

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_charmedk8scontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_charmedk8scontrolplanes.yaml
@@ -203,8 +203,6 @@ spec:
                   that still have not been created.
                 format: int32
                 type: integer
-            required:
-            - initialized
             type: object
         type: object
     served: true

--- a/controllers/charmedk8scontrolplane_controller.go
+++ b/controllers/charmedk8scontrolplane_controller.go
@@ -226,7 +226,7 @@ func (r *CharmedK8sControlPlaneReconciler) Reconcile(ctx context.Context, req ct
 			log.Error(err, "failed to update CharmedK8sControlPlane Status")
 		}
 
-		// Always attempt to Patch the MicroK8sControlPlane object and status after each reconciliation.
+		// Always attempt to Patch the CharmedK8sControlPlane object and status after each reconciliation.
 		if err := patchCharmedK8sControlPlane(ctx, patchHelper, kcp, patch.WithStatusObservedGeneration{}); err != nil {
 			log.Error(err, "failed to patch CharmedK8sControlPlane")
 		}
@@ -852,7 +852,7 @@ func (r *CharmedK8sControlPlaneReconciler) updateStatus(ctx context.Context, kcp
 	kubeclient, err := r.kubeClientForCluster(ctx, cluster)
 	if err != nil {
 		log.Error(err, "failed to get kubernetes client for the cluster")
-		return nil
+		return err
 	}
 
 	// kubeclient can be nil if the secret did not exist yet

--- a/controllers/charmedk8scontrolplane_controller.go
+++ b/controllers/charmedk8scontrolplane_controller.go
@@ -218,25 +218,6 @@ func (r *CharmedK8sControlPlaneReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	// examine DeletionTimestamp to determine if object is under deletion
-	if kcp.ObjectMeta.DeletionTimestamp.IsZero() {
-		// The object is not being deleted, so if it does not have our finalizer,
-		// then lets add the finalizer and update the object. This is equivalent
-		// registering our finalizer.
-		if !controllerutil.ContainsFinalizer(kcp, controlplanev1beta1.CharmedK8sControlPlaneFinalizer) {
-			controllerutil.AddFinalizer(kcp, controlplanev1beta1.CharmedK8sControlPlaneFinalizer)
-			if err := r.Update(ctx, kcp); err != nil {
-				return ctrl.Result{}, err
-			}
-			log.Info("added finalizer")
-			return ctrl.Result{}, nil
-		}
-	} else {
-		// The control plane object is being deleted
-		log.Info("deleting control plane")
-		return r.reconcileDelete(ctx, cluster, kcp)
-	}
-
 	defer func() {
 		log.Info("attempting to set control plane status")
 

--- a/go.mod
+++ b/go.mod
@@ -173,7 +173,7 @@ require (
 	golang.org/x/sys v0.4.0 // indirect
 	golang.org/x/term v0.4.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
-	golang.org/x/time v0.0.0-20220609170525-579cf78fd858 // indirect
+	golang.org/x/time v0.0.0-20220609170525-579cf78fd858
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,6 @@ github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cb
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmed-kubernetes/cluster-api-bootstrap-provider-charmed-k8s v0.0.0-20230206182445-ed51d8bd120d h1:zuREGURvaoVx+1BakwUsUlQCD8SJEHc4tpKkyO+kyqY=
 github.com/charmed-kubernetes/cluster-api-bootstrap-provider-charmed-k8s v0.0.0-20230206182445-ed51d8bd120d/go.mod h1:SSubNXrjRqFZkHjMqiw/i7vodLBjh0Y+vLnTrhaSyDM=
-github.com/charmed-kubernetes/cluster-api-provider-juju v0.0.0-20230309155616-f1f9ca5b1353 h1:+oOGy+3Qs+3uNTqxABnYDe05ftjz+l5JOVAiQBPRYms=
-github.com/charmed-kubernetes/cluster-api-provider-juju v0.0.0-20230309155616-f1f9ca5b1353/go.mod h1:LBvy7kKMsy7yyS3OOeXlj19oBePC1oIBitViIalRlMg=
 github.com/charmed-kubernetes/cluster-api-provider-juju v0.0.0-20230313164432-7338531245c8 h1:CQLKXpyKHScvIi9LWjw7mZ1a2kclCkfBQuCtux2TZB8=
 github.com/charmed-kubernetes/cluster-api-provider-juju v0.0.0-20230313164432-7338531245c8/go.mod h1:LBvy7kKMsy7yyS3OOeXlj19oBePC1oIBitViIalRlMg=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=


### PR DESCRIPTION
This PR adds status reconciliation for the control plane provider, and also configures the node provider IDs to match what is specified by the clusterAPI Machine resources. 

Additionally, it uses a non-default rate limiter with a shorter max delay time (5 minutes vs the previous 16 minutes) for most requeue calls. The requeue for status reconcilation happens every 30 seconds and is not rate limited in order for updates to occur at frequent intervals. 