### PR TITLE
remove provider ID handling since its now done by the machine controller

### DIFF
--- a/config/samples/controlplane_v1beta1_charmedk8scontrolplane.yaml
+++ b/config/samples/controlplane_v1beta1_charmedk8scontrolplane.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   template:
     spec:
+      useJujuProviderID: false
       constraints: "cores=2,mem=8G,root-disk=16G"
 ---
 

--- a/config/samples/infrastructure_v1beta1_jujucluster.yaml
+++ b/config/samples/infrastructure_v1beta1_jujucluster.yaml
@@ -9,9 +9,62 @@ metadata:
     app.kubernetes.io/created-by: cluster-api-provider-juju
   name: jujucluster-sample
 spec:
+  model:
+    name: jujucluster-sample
+    cloudRegion: Boston
+    config: 
+      juju-http-proxy: "http://squid.internal:3128"
+      apt-http-proxy: "http://squid.internal:3128"
+      snap-http-proxy: "http://squid.internal:3128"
+      juju-https-proxy: "http://squid.internal:3128"
+      apt-https-proxy: "http://squid.internal:3128"
+      snap-https-proxy: "http://squid.internal:3128"
+      apt-no-proxy: "localhost,127.0.0.1,ppa.launchpad.net,launchpad.net"
+      juju-no-proxy: "localhost,127.0.0.1,0.0.0.0,ppa.launchpad.net,launchpad.net,10.0.8.0/24,10.246.154.0/24"
+      logging-config: "<root>=DEBUG"
+      datastore: "vsanDatastore"
+      primary-network: "VLAN_2764"
+      force-vm-hardware-version: "17"
+    constraints:
+      arch: amd64
   # using loadbalancer requires metallb on vsphere
   controllerServiceType: loadbalancer
-  cloudEndpoint: 10.246.152.100
+  credential:
+    credentialSecretName: jujucluster-sample-credential-secret
+    credentialSecretNamespace: default
+  cloud:
+    name: jujucluster-sample
+    type: vsphere
+    endpoint: 10.246.152.100
+    regions:
+      - name: Boston
+        endpoint: 10.246.152.100
+    authTypes:
+      - "userpass"
+  additionalApplications:
+    - charmName: vsphere-integrator      
+      applicationName: vsphere-integrator
+      charmChannel: 1.27/edge
+      charmBase: ubuntu@22.04
+      units: 1
+      config:   
+        datastore: vsanDatastore
+        folder: k8s-crew-root 
+      trust: true
+    - charmName: vsphere-cloud-provider      
+      applicationName: vsphere-cloud-provider
+      charmChannel: 1.27/edge
+      charmBase: ubuntu@22.04
+      units: 0
+  additionalIntegrations:
+    - - vsphere-cloud-provider:vsphere-integration
+      - vsphere-integrator:clients
+    - - vsphere-cloud-provider:certificates
+      - easyrsa:client
+    - - vsphere-cloud-provider:kube-control
+      - kubernetes-control-plane:kube-control
+    - - vsphere-cloud-provider:external-cloud-provider
+      - kubernetes-control-plane:external-cloud-provider
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster

--- a/config/samples/infrastructure_v1beta1_jujucluster.yaml
+++ b/config/samples/infrastructure_v1beta1_jujucluster.yaml
@@ -42,29 +42,30 @@ spec:
     authTypes:
       - "userpass"
   additionalApplications:
-    - charmName: vsphere-integrator      
-      applicationName: vsphere-integrator
-      charmChannel: 1.27/edge
-      charmBase: ubuntu@22.04
-      units: 1
-      config:   
-        datastore: vsanDatastore
-        folder: k8s-crew-root 
-      trust: true
-    - charmName: vsphere-cloud-provider      
-      applicationName: vsphere-cloud-provider
-      charmChannel: 1.27/edge
-      charmBase: ubuntu@22.04
-      units: 0
-  additionalIntegrations:
-    - - vsphere-cloud-provider:vsphere-integration
-      - vsphere-integrator:clients
-    - - vsphere-cloud-provider:certificates
-      - easyrsa:client
-    - - vsphere-cloud-provider:kube-control
-      - kubernetes-control-plane:kube-control
-    - - vsphere-cloud-provider:external-cloud-provider
-      - kubernetes-control-plane:external-cloud-provider
+    applications:
+      vsphere-integrator:
+        charm: vsphere-integrator      
+        channel: 1.27/edge
+        base: ubuntu@22.04
+        numUnits: 1
+        options:   
+          datastore: vsanDatastore
+          folder: k8s-crew-root 
+        requiresTrust: true
+      vsphere-cloud-provider:
+        charm: vsphere-cloud-provider      
+        channel: 1.27/edge
+        base: ubuntu@22.04
+        numUnits: 0
+    integrations:
+      - - vsphere-cloud-provider:vsphere-integration
+        - vsphere-integrator:clients
+      - - vsphere-cloud-provider:certificates
+        - easyrsa:client
+      - - vsphere-cloud-provider:kube-control
+        - kubernetes-control-plane:kube-control
+      - - vsphere-cloud-provider:external-cloud-provider
+        - kubernetes-control-plane:external-cloud-provider
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster


### PR DESCRIPTION
This PR removes the provider ID handling that was being done by the control plane controller in order to force node provider IDs to match what the machine specified in the event a cloud provider was not deployed. 

Since this is now being handled in the machine controller ([this PR](https://github.com/charmed-kubernetes/cluster-api-provider-juju/pull/11), this functionality is no longer needed, and was probably not really a good fit for the control plane provider anyways. 