### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,94 +1,9 @@
 # cluster-api-control-plane-provider-charmed-k8s
-// TODO(user): Add simple overview of use/purpose
+A Cluster API control plane provider for [Charmed Kubernetes](https://ubuntu.com/kubernetes/charmed-k8s).
 
 ## Description
-// TODO(user): An in-depth paragraph about your project and overview of use
+This Cluster API control plane provider manages [Charmed Kubernetes](https://ubuntu.com/kubernetes/charmed-k8s) control plane components.
+This provider is used alongside the [Juju Infrastructure Provider](https://github.com/charmed-kubernetes/cluster-api-provider-juju)
+and the [Charmed Kubernetes Bootstrap Provider](https://github.com/charmed-kubernetes/cluster-api-bootstrap-provider-charmed-k8s). It does not work with other Cluster API providers
 
-## Getting Started
-You’ll need a Kubernetes cluster to run against. You can use [KIND](https://sigs.k8s.io/kind) to get a local cluster for testing, or run against a remote cluster.
-**Note:** Your controller will automatically use the current context in your kubeconfig file (i.e. whatever cluster `kubectl cluster-info` shows).
-
-### Running on the cluster
-1. Install Instances of Custom Resources:
-
-```sh
-kubectl apply -f config/samples/
-```
-
-2. Build and push your image to the location specified by `IMG`:
-	
-```sh
-make docker-build docker-push IMG=<some-registry>/cluster-api-control-plane-provider-charmed-k8s:tag
-```
-	
-3. Deploy the controller to the cluster with the image specified by `IMG`:
-
-```sh
-make deploy IMG=<some-registry>/cluster-api-control-plane-provider-charmed-k8s:tag
-```
-
-### Uninstall CRDs
-To delete the CRDs from the cluster:
-
-```sh
-make uninstall
-```
-
-### Undeploy controller
-UnDeploy the controller to the cluster:
-
-```sh
-make undeploy
-```
-
-## Contributing
-// TODO(user): Add detailed information on how you would like others to contribute to this project
-
-### How it works
-This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)
-
-It uses [Controllers](https://kubernetes.io/docs/concepts/architecture/controller/) 
-which provides a reconcile function responsible for synchronizing resources untile the desired state is reached on the cluster 
-
-### Test It Out
-1. Install the CRDs into the cluster:
-
-```sh
-make install
-```
-
-2. Run your controller (this will run in the foreground, so switch to a new terminal if you want to leave it running):
-
-```sh
-make run
-```
-
-**NOTE:** You can also run this in one step by running: `make install run`
-
-### Modifying the API definitions
-If you are editing the API definitions, generate the manifests such as CRs or CRDs using:
-
-```sh
-make manifests
-```
-
-**NOTE:** Run `make --help` for more information on all potential `make` targets
-
-More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
-
-## License
-
-Copyright 2022.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
+Please see the [Juju Infrastructure Provider repository](https://github.com/charmed-kubernetes/cluster-api-provider-juju) for details on using these providers.

--- a/config/samples/infrastructure_v1beta1_jujucluster.yaml
+++ b/config/samples/infrastructure_v1beta1_jujucluster.yaml
@@ -42,7 +42,7 @@ spec:
     authTypes:
       - "userpass"
   defaultApplicationConfigs:
-    defaultChannel: 1.27/edge
+    defaultChannel: 1.27/stable
     defaultBase: ubuntu@22.04
     kubernetesControlPlaneConfig:
       options:
@@ -51,14 +51,14 @@ spec:
         enable-dashboard-addons: false
         allow-privileged: "true"
         ignore-kube-system-pods: "coredns vsphere-cloud-controller-manager"
-      channel: 1.27/edge
+      channel: 1.27/stable
       base: ubuntu@22.04
       expose: true
     kubernetesWorkerConfig:
       options:
         ignore-missing-cni: true
         ingress: false
-      channel: 1.27/edge
+      channel: 1.27/stable
       base: ubuntu@22.04
       expose: true
     easyRSAConfig:
@@ -66,20 +66,20 @@ spec:
         cores: 1
         mem: 4000
         root-disk: 16000
-      channel: 1.27/edge
+      channel: 1.27/stable
       base: ubuntu@22.04
     kubeApiLoadBalancerConfig:
       constraints:
         cores: 1
         mem: 4000
         root-disk: 16000
-      channel: 1.27/edge
+      channel: 1.27/stable
       base: ubuntu@22.04
   additionalApplications:
     applications:
       vsphere-integrator:
         charm: vsphere-integrator      
-        channel: 1.27/edge
+        channel: 1.27/stable
         base: ubuntu@22.04
         numUnits: 1
         options:   
@@ -88,7 +88,7 @@ spec:
         requiresTrust: true
       vsphere-cloud-provider:
         charm: vsphere-cloud-provider      
-        channel: 1.27/edge
+        channel: 1.27/stable
         base: ubuntu@22.04
         numUnits: 0
     integrations:


### PR DESCRIPTION
This PR updates the readme to a simplied form, directing users to the main juju infra readme that has all the details about deployments. It also updates the sample config to use 1.27/stable channels instead of edge