### PR TITLE
Parsing fix and integration tests

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -1,0 +1,64 @@
+name: Test Suite
+on:
+  pull_request:
+
+jobs:
+  integration-test:
+    name: VSphere Integration Test
+    runs-on: self-hosted
+    timeout-minutes: 120
+    env: 
+      # These secrets are repository secrets
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      B64_CREDS: ${{ secrets.B64_ENCODED_CI_CREDS }}
+      # GITHUB_TOKEN is an automatically included secret available to the workflow
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+      - name: Set cluster resources env
+        # the cluster resources are expected to be provided to pytest as an env var which holds a base64 encoded string
+        # since it will be a multiline env var special care is needed
+        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+        run: |
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "B64_RESOURCES<<$EOF" >> "$GITHUB_ENV"
+          base64 test/data/ci-resources.yaml >> "$GITHUB_ENV"
+          echo "$EOF" >> "$GITHUB_ENV"
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: vsphere
+          juju-channel: 3.1/stable
+          credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
+          clouds-yaml: ${{ secrets.CLOUDS_YAML }}
+          bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
+          bootstrap-options: >-
+            ${{ secrets.JAMMY_BOOTSTRAP_OPTIONS }}
+            --model-default datastore=vsanDatastore
+            --model-default primary-network=VLAN_2763
+            --model-default force-vm-hardware-version=17
+      - name: Run test
+        run: tox -c cluster-api-charmed-k8s-e2e -e e2e -- --infra-branch=parsing-fix-for-microk8s-clouds--control-plane-branch=$GITHUB_HEAD_REF --metallb-ip-range=10.246.153.253-10.246.153.253
+      - name: Setup Debug Artifact Collection
+        if: ${{ failure() }}
+        run: mkdir tmp
+      - name: Collect Juju Status
+        if: ${{ failure() }}
+        run: |
+          juju status 2>&1 | tee tmp/juju-status.txt
+          juju-crashdump -s -m controller -a debug-layer -a config -o tmp/
+          mv juju-crashdump-* tmp/ | true
+      - name: Upload debug artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-run-artifacts
+          path: tmp

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -46,7 +46,7 @@ jobs:
             --model-default primary-network=VLAN_2763
             --model-default force-vm-hardware-version=17
       - name: Run test
-        run: tox -c cluster-api-charmed-k8s-e2e -e e2e -- --infra-branch=parsing-fix-for-microk8s-clouds--control-plane-branch=$GITHUB_HEAD_REF --metallb-ip-range=10.246.153.253-10.246.153.253
+        run: tox -c cluster-api-charmed-k8s-e2e -e e2e -- --infra-branch=parsing-fix-for-microk8s-clouds --control-plane-branch=$GITHUB_HEAD_REF --metallb-ip-range=10.246.153.253-10.246.153.253
       - name: Setup Debug Artifact Collection
         if: ${{ failure() }}
         run: mkdir tmp

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -20,14 +20,7 @@ jobs:
         with:
           submodules: 'true'
       - name: Set cluster resources env
-        # the cluster resources are expected to be provided to pytest as an env var which holds a base64 encoded string
-        # since it will be a multiline env var special care is needed
-        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-        run: |
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "B64_RESOURCES<<$EOF" >> "$GITHUB_ENV"
-          base64 test/data/ci-resources.yaml >> "$GITHUB_ENV"
-          echo "$EOF" >> "$GITHUB_ENV"
+        run: echo "B64_RESOURCES=$(base64 -w0 test/data/ci-resources.yaml)" >> $GITHUB_ENV
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "cluster-api-charmed-k8s-e2e"]
 	path = cluster-api-charmed-k8s-e2e
 	url = https://github.com/charmed-kubernetes/cluster-api-charmed-k8s-e2e.git
-	branch = scp/testing
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "cluster-api-charmed-k8s-e2e"]
+	path = cluster-api-charmed-k8s-e2e
+	url = https://github.com/charmed-kubernetes/cluster-api-charmed-k8s-e2e.git
+	branch = scp/testing

--- a/controllers/charmedk8scontrolplane_controller.go
+++ b/controllers/charmedk8scontrolplane_controller.go
@@ -798,7 +798,7 @@ func getJujuConfigFromSecret(ctx context.Context, cluster *clusterv1.Cluster, c 
 		}
 	}
 	data := string(configSecret.Data["controller-data"][:])
-	split := strings.Split(data, fmt.Sprintf("%s:\n", cluster.Name+"-k8s-cloud"))
+	split := strings.SplitN(data, ":\n", 2)
 	yam := split[1]
 	config := JujuConfig{}
 	err := yaml.Unmarshal([]byte(yam), &config)

--- a/test/data/ci-resources.yaml
+++ b/test/data/ci-resources.yaml
@@ -1,0 +1,197 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: JujuCluster
+metadata:
+  labels:
+    app.kubernetes.io/name: jujucluster
+    app.kubernetes.io/instance: jujucluster-sample
+    app.kubernetes.io/part-of: cluster-api-provider-juju
+    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: cluster-api-provider-juju
+  name: jujucluster-sample
+spec:
+  model:
+    name: jujucluster-sample
+    cloudRegion: Boston
+    config: 
+      juju-http-proxy: "http://squid.internal:3128"
+      apt-http-proxy: "http://squid.internal:3128"
+      snap-http-proxy: "http://squid.internal:3128"
+      juju-https-proxy: "http://squid.internal:3128"
+      apt-https-proxy: "http://squid.internal:3128"
+      snap-https-proxy: "http://squid.internal:3128"
+      apt-no-proxy: "localhost,127.0.0.1,ppa.launchpad.net,launchpad.net"
+      juju-no-proxy: "localhost,127.0.0.1,0.0.0.0,ppa.launchpad.net,launchpad.net,10.0.8.0/24,10.246.154.0/24,10.246.153.0/24"
+      logging-config: "<root>=DEBUG"
+      datastore: "vsanDatastore"
+      primary-network: "VLAN_2763"
+      force-vm-hardware-version: "17"
+    constraints:
+      arch: amd64
+  # using loadbalancer requires metallb on vsphere
+  controllerServiceType: loadbalancer
+  credential:
+    credentialSecretName: jujucluster-sample-credential-secret
+    credentialSecretNamespace: default
+  cloud:
+    name: jujucluster-sample
+    type: vsphere
+    endpoint: 10.246.152.100
+    regions:
+      - name: Boston
+        endpoint: 10.246.152.100
+    authTypes:
+      - "userpass"
+  defaultApplicationConfigs:
+    defaultChannel: 1.27/stable
+    defaultBase: ubuntu@22.04
+    kubernetesControlPlaneConfig:
+      options:
+        ignore-missing-cni: true
+        enable-metrics: false
+        enable-dashboard-addons: false
+        allow-privileged: "true"
+        ignore-kube-system-pods: "coredns vsphere-cloud-controller-manager"
+      channel: 1.27/stable
+      base: ubuntu@22.04
+      expose: true
+    kubernetesWorkerConfig:
+      options:
+        ignore-missing-cni: true
+        ingress: false
+      channel: 1.27/stable
+      base: ubuntu@22.04
+      expose: true
+    easyRSAConfig:
+      constraints:
+        cores: 1
+        mem: 4000
+        root-disk: 16000
+      channel: 1.27/stable
+      base: ubuntu@22.04
+    kubeApiLoadBalancerConfig:
+      constraints:
+        cores: 1
+        mem: 4000
+        root-disk: 16000
+      channel: 1.27/stable
+      base: ubuntu@22.04
+  additionalApplications:
+    applications:
+      vsphere-integrator:
+        charm: vsphere-integrator      
+        channel: 1.27/stable
+        base: ubuntu@22.04
+        numUnits: 1
+        options:   
+          datastore: vsanDatastore
+          folder: k8s-ci-root 
+        requiresTrust: true
+      vsphere-cloud-provider:
+        charm: vsphere-cloud-provider      
+        channel: 1.27/stable
+        base: ubuntu@22.04
+        numUnits: 0
+    integrations:
+      - - vsphere-cloud-provider:vsphere-integration
+        - vsphere-integrator:clients
+      - - vsphere-cloud-provider:certificates
+        - easyrsa:client
+      - - vsphere-cloud-provider:kube-control
+        - kubernetes-control-plane:kube-control
+      - - vsphere-cloud-provider:external-cloud-provider
+        - kubernetes-control-plane:external-cloud-provider
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: cluster-sample
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: JujuCluster
+    name: jujucluster-sample
+  controlPlaneRef:
+    kind: CharmedK8sControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    name: charmedk8scontrolplane-sample
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: JujuMachineTemplate
+metadata:
+  name: jujumachinetemplate-controlplane
+spec:
+  template:
+    spec:
+      useJujuProviderID: false
+      constraints: 
+        cores: 2
+        mem: 8000
+        root-disk: 16000
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: CharmedK8sControlPlane
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: cluster-sample
+    app.kubernetes.io/name: charmedk8scontrolplane
+    app.kubernetes.io/instance: charmedk8scontrolplane-sample
+    app.kubernetes.io/part-of: cluster-api-control-plane-provider-charmed-k8s
+    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: cluster-api-control-plane-provider-charmed-k8s
+  name: charmedk8scontrolplane-sample
+spec:
+  replicas: 1
+  machineTemplate:
+    kind: JujuMachineTemplate
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    name: jujumachinetemplate-controlplane
+  controlPlaneConfig:
+    controlPlaneApplications:
+      - kubernetes-control-plane
+      - etcd
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: machinedeployment-sample
+spec:
+  clusterName: cluster-sample
+  replicas: 1
+  template:
+    spec:
+      clusterName: cluster-sample
+      bootstrap:
+        configRef:
+          name: charmedk8sconfig-machinedeployment
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: CharmedK8sConfigTemplate
+      infrastructureRef:
+        name: jujumachinetemplate-machinedeployment
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: JujuMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: JujuMachineTemplate
+metadata:
+  name: jujumachinetemplate-machinedeployment
+spec:
+  template:
+    spec:
+      useJujuProviderID: false
+      constraints: 
+        cores: 2
+        mem: 8000
+        root-disk: 16000
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: CharmedK8sConfigTemplate
+metadata:
+  name: charmedk8sconfig-machinedeployment
+spec:
+  template:
+    spec:
+      workerApplications:
+        - kubernetes-worker


### PR DESCRIPTION
This PR adds the shared integration testing as a submodule, and fixes a bug when running in microk8s. We were previously operating under the assumption the controller namespace is named controller-{jujuclusterName}, however on some clouds juju appends additional information to the end of that, causing controller config parsing issues. 

This PR should not be merged until [the e2e tests](https://github.com/charmed-kubernetes/cluster-api-charmed-k8s-e2e/pull/2) are in main, at which point the submodule branch will be updated to point to main instead of the PR branch it currently points to. At that point this PR can be merged

A second PR will be necessary after the merging of [the infra PR](https://github.com/charmed-kubernetes/cluster-api-charmed-k8s-e2e/pull/2) in order to update the infra branch name used in the tox invocation 